### PR TITLE
docker: update to v0.4.0.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "docker"]
 	path = docker
 	url = https://github.com/cnpem/epics-in-docker
+	branch = release

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# EPICS IOC for ADSimDetector
+
+This repository contains the EPICS Input/Output Controller (IOC) used at LNLS
+for debugging, testing and prototyping based on [areaDetector simulation
+detector (ADSimDetector)](https://github.com/areaDetector/ADSimDetector).
+
+## Running the IOC
+
+You can use the following command to run it in the background using the default
+start-up script from [epics-in-docker][epics-in-docker].
+
+```bash
+docker compose up -d
+```
+
+You can then access the IOC shell through [the Unix socket created][iocsh].
+
+[epics-in-docker]: https://github.com/cnpem/epics-in-docker
+[iocsh]: https://github.com/cnpem/epics-in-docker/tree/v0.4.0#accessing-iocsh-inside-containers
+
+## Building the IOC image
+
+You can build the IOC with the following command:
+
+```bash
+docker compose build
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,3 @@ services:
         REPONAME: ad-sim-epics-ioc
         RUNTIME_PACKAGES: libxml2 libtiff5
         RUNDIR: /opt/ad-sim-epics-ioc/iocBoot/iocsimulator
-        ENTRYPOINT: ./run.sh

--- a/iocBoot/iocsimulator/run.sh
+++ b/iocBoot/iocsimulator/run.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-procServ -f -i ^C^D -L - unix:./ioc.sock ./st.cmd


### PR DESCRIPTION
Default entrypoint script from epics-in-docker v0.4.0 replaces our custom script, which has been now removed. `epics-in-docker` submodule should also follow the `release` branch for ease update.

This also fixes the documentation of IOC shell access for Unix sockets (#2).