### PR TITLE
boot: add iocs script configuration in start-up example.

### DIFF
--- a/iocBoot/iocsimulator/st.cmd
+++ b/iocBoot/iocsimulator/st.cmd
@@ -1,4 +1,7 @@
-#!../../bin/linux-x86_64/simulator
+#!/opt/ad-sim-epics-ioc/bin/linux-x86_64/simulator
+# -*- container-image: ghcr.io/cnpem/ad-sim-epics-ioc
+
+cd /opt/ad-sim-epics-ioc/iocBoot/iocsimulator
 
 < envPaths
 


### PR DESCRIPTION
The `st.cmd` iocsh script can be defined to support the SIRIUS iocs script without affecting the users that don't use it. Since it is convenient and commonly used in the SIRIUS beamlines, we now add support for it.