### PR TITLE
Support RGB color modes by default via CA

### DIFF
--- a/iocBoot/iocsimulator/st.cmd
+++ b/iocBoot/iocsimulator/st.cmd
@@ -13,7 +13,7 @@ simulator_registerRecordDeviceDriver(pdbbase)
 epicsEnvSet("PREFIX", "SIM:")
 epicsEnvSet("MAX_IMAGE_WIDTH", 1024)
 epicsEnvSet("MAX_IMAGE_HEIGHT", 1024)
-epicsEnvSet("MAX_IMAGE_PIXELS", 1232896)
+epicsEnvSet("MAX_IMAGE_PIXELS", 3145728)
 
 # Define simulator driver port
 epicsEnvSet("PORT", "SIM")


### PR DESCRIPTION
This patch sets the max number of pixels to 3x the size of a 2D image (Width * Height), so all three color channels can be passed. I would like for that value to be directly inferred from `MAX_IMAGE_WIDTH` and `MAX_IMAGE_HEIGHT`, but idk if that works! 

Previously, trying to use those RGB colors directly would cut out most of the color channels, since it would reach the maximum ArrayData size. Now, they work correctly without any manual changes.

Previously, with no changes to `st.cmd` (example with RGB3 so it's clearer what the issue is):
![The image is cut out, precisely because the data is incomplete, due to the maximum number of pixels being changes in this PR](https://github.com/cnpem/ad-sim-epics-ioc/assets/9145768/75d4aff4-464e-4517-ac8a-fecc40441ca2)
